### PR TITLE
Center the background image.

### DIFF
--- a/tab.html
+++ b/tab.html
@@ -14,6 +14,7 @@
         width: 100vw;
         height: 100vh;
         background-size: cover;
+        background-position: center;
       }
 
       .picker-label {


### PR DESCRIPTION
For any screen size other than the full-screen, the background image would become lop-sided. This commit fixes it.